### PR TITLE
Shared notes text

### DIFF
--- a/src/stores/models/Note.js
+++ b/src/stores/models/Note.js
@@ -39,7 +39,7 @@ export default Note = types.model('Note', {
       if (this.secret_token()) {
         try {
           var decryptedText;
-          if (this._microblog.is_shared) {
+          if (self._microblog.is_shared) {
             decryptedText = self.content_text;
           }
           else {
@@ -54,7 +54,7 @@ export default Note = types.model('Note', {
         return self.content_text;
       }
     },
-    
+
     truncated_text(num_chars = 100) {
       var s = self.decrypted_text();
       if (s.length > num_chars) {


### PR DESCRIPTION
Just a quick fix to not decrypt shared notes. Shared notes are saved decrypted because they have to be included on the blog, so Micro.blog has to have the plain text version.