### PR TITLE
Fixes a double "mkey" when already present.

### DIFF
--- a/src/components/menu/account_switcher.js
+++ b/src/components/menu/account_switcher.js
@@ -67,7 +67,9 @@ export default class AccountSwitcher extends React.Component {
         </View>
         { this.state.is_showing_key ? 
           <View style={{ marginTop: 25, marginBottom: 15 }}>
-            <Text selectable={true} style={{ color: App.theme_text_color() }}>mkey{ Auth.selected_user.secret_token() }</Text>
+            <Text selectable={true} style={{ color: App.theme_text_color() }}>
+              { Auth.selected_user.secret_token().includes("mkey") ? Auth.selected_user.secret_token() : `mkey${Auth.selected_user.secret_token()}` }
+            </Text>
           </View>
         : null }
       </View>


### PR DESCRIPTION
Hey @manton,

This is just a very minor fix to not show a duplicate "mkey" value in the secret key if you previously saved it like that — which could have been the case if you copied it from the web and copy/pasted straight to iOS or saved in a password manager.